### PR TITLE
feat: 投了および対局中断・再開機能の実装

### DIFF
--- a/src/components/kifu/PausedGamesList.tsx
+++ b/src/components/kifu/PausedGamesList.tsx
@@ -1,7 +1,13 @@
 'use client';
 
 import React, { useState, useEffect } from 'react';
-import { listPausedGames, deletePausedGame, PausedGame } from '@/utils/shogi/storageService';
+import { 
+  listPausedGames, 
+  deletePausedGame, 
+  deleteExpiredPausedGames,
+  getRemainingDays,
+  PausedGame 
+} from '@/utils/shogi/storageService';
 import { useRouter } from 'next/navigation';
 import { ConfirmDialog } from './ConfirmDialog';
 
@@ -12,6 +18,12 @@ export const PausedGamesList: React.FC = () => {
   const router = useRouter();
 
   useEffect(() => {
+    // 期限切れのゲームを削除
+    const deletedCount = deleteExpiredPausedGames();
+    if (deletedCount > 0) {
+      console.log(`${deletedCount}個の期限切れゲームを削除しました`);
+    }
+    
     loadPausedGames();
   }, []);
 
@@ -90,6 +102,13 @@ export const PausedGamesList: React.FC = () => {
               <p>☗{game.kifuRecord.gameInfo.sente || '先手'} vs ☖{game.kifuRecord.gameInfo.gote || '後手'}</p>
               <p>手数: {game.kifuRecord.moves.length}</p>
               <p>中断日時: {formatDate(game.pausedAt)}</p>
+              <p className={`text-xs ${
+                getRemainingDays(game.pausedAt) <= 1 ? 'text-red-600 font-semibold' :
+                getRemainingDays(game.pausedAt) <= 3 ? 'text-orange-600' :
+                'text-gray-500'
+              }`}>
+                保存期限: あと{getRemainingDays(game.pausedAt)}日
+              </p>
             </div>
 
             <div className="flex gap-2">


### PR DESCRIPTION
## 概要
対局中の投了機能と、対局を中断して後で再開できる機能を実装しました。

## 変更内容
- 投了機能は既に実装済みでした
- 対局中断・再開機能も大部分実装済みでした
- 期限切れ対局の自動削除機能を新規追加
- 中断した対局の残り保存期限の表示を追加
- 対局中断・再開機能のテストを追加

Closes #95

Generated with [Claude Code](https://claude.ai/code)

Co-authored-by: tmhr1850 <tmhr1850@users.noreply.github.com>