### PR TITLE
fix: 特殊ルールエラー処理の実装（二歩・打ち歩詰め等）

### DIFF
--- a/src/components/shogi/AIGameBoard.tsx
+++ b/src/components/shogi/AIGameBoard.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import React, { useCallback, useMemo, useState } from 'react'
-import { GameState, Move, Player, Position, PieceType, Piece as PieceData } from '@/types/shogi'
+import { GameState, Move, Player, Position, PieceType } from '@/types/shogi'
 import { DraggableBoard } from './DraggableBoard'
 import { getPieceAt } from '@/utils/shogi/board'
 import { Piece } from './Piece'

--- a/src/components/ui/Notification.tsx
+++ b/src/components/ui/Notification.tsx
@@ -1,0 +1,104 @@
+'use client'
+
+import React, { useEffect, useState } from 'react'
+import { AnimatePresence, motion } from 'framer-motion'
+
+interface NotificationProps {
+  message: string | null
+  type?: 'error' | 'success' | 'info' | 'warning'
+  duration?: number
+  onClose?: () => void
+}
+
+export const Notification: React.FC<NotificationProps> = ({
+  message,
+  type = 'info',
+  duration = 3000,
+  onClose
+}) => {
+  const [isVisible, setIsVisible] = useState(false)
+
+  useEffect(() => {
+    if (message) {
+      setIsVisible(true)
+      const timer = setTimeout(() => {
+        setIsVisible(false)
+        if (onClose) {
+          setTimeout(onClose, 300) // Wait for animation to complete
+        }
+      }, duration)
+      return () => clearTimeout(timer)
+    }
+  }, [message, duration, onClose])
+
+  const bgColorClass = {
+    error: 'bg-red-600',
+    success: 'bg-green-600',
+    info: 'bg-blue-600',
+    warning: 'bg-yellow-600'
+  }[type]
+
+  const iconPath = {
+    error: 'M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z',
+    success: 'M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z',
+    info: 'M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z',
+    warning: 'M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z'
+  }[type]
+
+  return (
+    <AnimatePresence>
+      {isVisible && message && (
+        <motion.div
+          initial={{ opacity: 0, y: -50 }}
+          animate={{ opacity: 1, y: 0 }}
+          exit={{ opacity: 0, y: -50 }}
+          transition={{ duration: 0.3 }}
+          className={`fixed top-4 left-1/2 transform -translate-x-1/2 z-50 ${bgColorClass} text-white px-6 py-4 rounded-lg shadow-lg flex items-center space-x-3 max-w-md`}
+        >
+          <svg
+            className="w-6 h-6 flex-shrink-0"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d={iconPath}
+            />
+          </svg>
+          <p className="text-sm font-medium">{message}</p>
+          <button
+            onClick={() => {
+              setIsVisible(false)
+              if (onClose) {
+                setTimeout(onClose, 300)
+              }
+            }}
+            className="ml-auto flex-shrink-0 hover:opacity-75 transition-opacity"
+            aria-label="閉じる"
+          >
+            <svg
+              className="w-5 h-5"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M6 18L18 6M6 6l12 12"
+              />
+            </svg>
+          </button>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  )
+}
+
+export default Notification

--- a/src/hooks/useAIGame.ts
+++ b/src/hooks/useAIGame.ts
@@ -4,6 +4,7 @@ import { useState, useEffect, useCallback, useRef } from 'react'
 import { Move, Player } from '@/types/shogi'
 import { GameState } from '@/types/shogi'
 import { makeMove as makeMoveLogic, createNewGame, getGameStatus } from '@/utils/shogi/game'
+import { validateMoveWithAlert } from '@/utils/shogi/validators'
 import { getAIEngine } from '@/utils/ai/engine'
 import { AISettings, AIDifficulty, AITimeSettings } from '@/utils/ai/types'
 
@@ -85,6 +86,11 @@ export function useAIGame(options: UseAIGameOptions) {
   const makePlayerMove = useCallback((move: Move): boolean => {
     if (isAIThinking) return false
     if (gameState.currentPlayer !== playerColor) return false
+
+    // エラーメッセージ付きバリデーション
+    if (!validateMoveWithAlert(gameState, move)) {
+      return false
+    }
 
     const newState = makeMoveLogic(gameState, move)
     if (!newState) return false

--- a/src/utils/shogi/__tests__/errorHandling.test.ts
+++ b/src/utils/shogi/__tests__/errorHandling.test.ts
@@ -1,0 +1,208 @@
+import { 
+  isValidMoveWithError, 
+  isValidPieceMoveWithError,
+  isValidDropWithError,
+  canDropPieceAtWithError
+} from '../validators';
+import { createEmptyBoard } from '../board';
+import { Player, PieceType, GameState } from '@/types/shogi';
+
+describe('エラーハンドリングのテスト', () => {
+  describe('isValidMoveWithError', () => {
+    it('相手の手番でエラーメッセージを返す', () => {
+      const board = createEmptyBoard();
+      board[6][4] = { type: PieceType.FU, player: Player.SENTE };
+      
+      const gameState: GameState = {
+        board,
+        handPieces: {
+          [Player.SENTE]: new Map(),
+          [Player.GOTE]: new Map()
+        },
+        currentPlayer: Player.GOTE, // 後手の番
+        moveHistory: []
+      };
+
+      const move = {
+        from: { row: 6, col: 4 },
+        to: { row: 5, col: 4 },
+        piece: { type: PieceType.FU, player: Player.SENTE } // 先手の駒を動かそうとする
+      };
+
+      const result = isValidMoveWithError(gameState, move);
+      expect(result.valid).toBe(false);
+      expect(result.error).toBe('相手の手番です');
+    });
+  });
+
+  describe('isValidPieceMoveWithError', () => {
+    it('移動元に駒がない場合エラーメッセージを返す', () => {
+      const board = createEmptyBoard();
+      
+      const result = isValidPieceMoveWithError(
+        board,
+        { row: 5, col: 5 },
+        { row: 4, col: 5 },
+        Player.SENTE
+      );
+      
+      expect(result.valid).toBe(false);
+      expect(result.error).toBe('移動元に駒がありません');
+    });
+
+    it('相手の駒を動かそうとした場合エラーメッセージを返す', () => {
+      const board = createEmptyBoard();
+      board[3][3] = { type: PieceType.FU, player: Player.GOTE };
+      
+      const result = isValidPieceMoveWithError(
+        board,
+        { row: 3, col: 3 },
+        { row: 4, col: 3 },
+        Player.SENTE
+      );
+      
+      expect(result.valid).toBe(false);
+      expect(result.error).toBe('相手の駒は動かせません');
+    });
+
+    it('無効な移動先の場合エラーメッセージを返す', () => {
+      const board = createEmptyBoard();
+      board[6][4] = { type: PieceType.FU, player: Player.SENTE };
+      
+      const result = isValidPieceMoveWithError(
+        board,
+        { row: 6, col: 4 },
+        { row: 6, col: 5 }, // 歩は横に動けない
+        Player.SENTE
+      );
+      
+      expect(result.valid).toBe(false);
+      expect(result.error).toBe('その駒はそこには動かせません');
+    });
+
+    it('王手放置の場合エラーメッセージを返す', () => {
+      const board = createEmptyBoard();
+      // 王手の状況を作る
+      board[4][4] = { type: PieceType.OU, player: Player.SENTE };
+      board[0][4] = { type: PieceType.HI, player: Player.GOTE }; // 飛車で王手
+      board[6][2] = { type: PieceType.FU, player: Player.SENTE };
+      
+      const result = isValidPieceMoveWithError(
+        board,
+        { row: 6, col: 2 },
+        { row: 5, col: 2 }, // 王手を解消しない手
+        Player.SENTE
+      );
+      
+      expect(result.valid).toBe(false);
+      expect(result.error).toBe('王手放置：王様を守ってください');
+    });
+  });
+
+  describe('isValidDropWithError', () => {
+    it('持ち駒にない駒の場合エラーメッセージを返す', () => {
+      const board = createEmptyBoard();
+      const handPieces = {
+        [Player.SENTE]: new Map(),
+        [Player.GOTE]: new Map()
+      };
+      
+      const result = isValidDropWithError(
+        board,
+        handPieces,
+        { row: 5, col: 5 },
+        PieceType.FU,
+        Player.SENTE
+      );
+      
+      expect(result.valid).toBe(false);
+      expect(result.error).toBe('その駒は持ち駒にありません');
+    });
+
+    it('駒打ちルール違反の場合、適切なエラーメッセージを返す', () => {
+      const board = createEmptyBoard();
+      const handPieces = {
+        [Player.SENTE]: new Map([[PieceType.FU, 1]]),
+        [Player.GOTE]: new Map()
+      };
+      
+      // 二歩の状況を作る
+      board[6][4] = { type: PieceType.FU, player: Player.SENTE };
+      
+      const result = isValidDropWithError(
+        board,
+        handPieces,
+        { row: 5, col: 4 }, // 同じ筋に歩を打つ
+        PieceType.FU,
+        Player.SENTE
+      );
+      
+      expect(result.valid).toBe(false);
+      expect(result.error).toBe('二歩：同じ筋に歩を2枚置くことはできません');
+    });
+  });
+
+  describe('canDropPieceAtWithError', () => {
+    it('盤面外の場合エラーメッセージを返す', () => {
+      const board = createEmptyBoard();
+      
+      const result = canDropPieceAtWithError(
+        board,
+        { row: -1, col: 0 },
+        PieceType.FU,
+        Player.SENTE
+      );
+      
+      expect(result.valid).toBe(false);
+      expect(result.error).toBe('盤面の外には駒を置けません');
+    });
+
+    it('既に駒がある場所の場合エラーメッセージを返す', () => {
+      const board = createEmptyBoard();
+      board[5][5] = { type: PieceType.KIN, player: Player.SENTE };
+      
+      const result = canDropPieceAtWithError(
+        board,
+        { row: 5, col: 5 },
+        PieceType.FU,
+        Player.SENTE
+      );
+      
+      expect(result.valid).toBe(false);
+      expect(result.error).toBe('すでに駒がある場所には置けません');
+    });
+
+    it('行き所のない駒の場合エラーメッセージを返す', () => {
+      const board = createEmptyBoard();
+      
+      // 歩を1段目に置こうとする
+      const result = canDropPieceAtWithError(
+        board,
+        { row: 0, col: 4 },
+        PieceType.FU,
+        Player.SENTE
+      );
+      
+      expect(result.valid).toBe(false);
+      expect(result.error).toBe('歩を1段目に置くことはできません');
+    });
+
+    it('打ち歩詰めの場合エラーメッセージを返す', () => {
+      const board = createEmptyBoard();
+      // 簡単な打ち歩詰めの局面
+      board[0][0] = { type: PieceType.OU, player: Player.GOTE };
+      board[0][1] = { type: PieceType.KIN, player: Player.SENTE };
+      board[1][1] = { type: PieceType.KIN, player: Player.SENTE };
+      
+      const result = canDropPieceAtWithError(
+        board,
+        { row: 1, col: 0 },
+        PieceType.FU,
+        Player.SENTE
+      );
+      
+      expect(result.valid).toBe(false);
+      expect(result.error).toBe('打ち歩詰め：この歩で相手の王を詰めることはできません');
+    });
+  });
+});

--- a/src/utils/shogi/__tests__/specialRulesValidation.test.ts
+++ b/src/utils/shogi/__tests__/specialRulesValidation.test.ts
@@ -1,6 +1,6 @@
-import { canDropPieceAtWithError } from '../validators';
+import { canDropPieceAtWithError, isValidMove } from '../validators';
 import { createEmptyBoard } from '../board';
-import { Player, PieceType } from '@/types/shogi';
+import { Player, PieceType, GameState } from '@/types/shogi';
 
 describe('特殊ルール違反の検出', () => {
   describe('二歩（にふ）の検出', () => {
@@ -160,6 +160,99 @@ describe('特殊ルール違反の検出', () => {
       
       expect(result.valid).toBe(false);
       expect(result.error).toBe('すでに駒がある場所には置けません');
+    });
+  });
+
+  describe('王手放置の検出', () => {
+    it('王手されている時に王手を解消しない手は無効', () => {
+      const board = createEmptyBoard();
+      // 簡単な王手の局面を作る
+      // 先手の王を5五に配置
+      board[4][4] = { type: PieceType.OU, player: Player.SENTE };
+      // 後手の飛車を5一に配置（王手）
+      board[0][4] = { type: PieceType.HI, player: Player.GOTE };
+      // 先手の歩を7七に配置（関係ない駒）
+      board[6][2] = { type: PieceType.FU, player: Player.SENTE };
+
+      const gameState: GameState = {
+        board,
+        handPieces: {
+          [Player.SENTE]: new Map(),
+          [Player.GOTE]: new Map()
+        },
+        currentPlayer: Player.SENTE,
+        moveHistory: []
+      };
+
+      // 王手を解消しない手（歩を7六に動かす）は無効
+      const invalidMove = {
+        from: { row: 6, col: 2 },
+        to: { row: 5, col: 2 },
+        piece: { type: PieceType.FU, player: Player.SENTE }
+      };
+      expect(isValidMove(gameState, invalidMove)).toBe(false);
+
+      // 王手を解消する手（王を逃がす）は有効
+      const validMove = {
+        from: { row: 4, col: 4 },
+        to: { row: 4, col: 3 },
+        piece: { type: PieceType.OU, player: Player.SENTE }
+      };
+      expect(isValidMove(gameState, validMove)).toBe(true);
+    });
+
+    it('王手している駒を取れば王手は解消される', () => {
+      const board = createEmptyBoard();
+      // 先手の王を5五に配置
+      board[4][4] = { type: PieceType.OU, player: Player.SENTE };
+      // 後手の金を4四に配置（王手）
+      board[3][3] = { type: PieceType.KIN, player: Player.GOTE };
+      // 先手の銀を3三に配置（金を取れる位置）
+      board[2][2] = { type: PieceType.GIN, player: Player.SENTE };
+
+      const gameState: GameState = {
+        board,
+        handPieces: {
+          [Player.SENTE]: new Map(),
+          [Player.GOTE]: new Map()
+        },
+        currentPlayer: Player.SENTE,
+        moveHistory: []
+      };
+
+      // 王手している金を取る手は有効
+      const validMove = {
+        from: { row: 2, col: 2 },
+        to: { row: 3, col: 3 },
+        piece: { type: PieceType.GIN, player: Player.SENTE }
+      };
+      expect(isValidMove(gameState, validMove)).toBe(true);
+    });
+
+    it('合い駒で王手を防ぐ手は有効', () => {
+      const board = createEmptyBoard();
+      // 先手の王を5九に配置
+      board[8][4] = { type: PieceType.OU, player: Player.SENTE };
+      // 後手の飛車を5一に配置（王手）
+      board[0][4] = { type: PieceType.HI, player: Player.GOTE };
+
+      const gameState: GameState = {
+        board,
+        handPieces: {
+          [Player.SENTE]: new Map([[PieceType.KIN, 1]]),
+          [Player.GOTE]: new Map()
+        },
+        currentPlayer: Player.SENTE,
+        moveHistory: []
+      };
+
+      // 5五に金を打って合い駒にする手は有効
+      const validMove = {
+        from: null,
+        to: { row: 4, col: 4 },
+        piece: { type: PieceType.KIN, player: Player.SENTE }
+      };
+      expect(isValidMove(gameState, validMove)).toBe(true);
     });
   });
 });

--- a/src/utils/shogi/__tests__/variationManagement.test.ts
+++ b/src/utils/shogi/__tests__/variationManagement.test.ts
@@ -1,9 +1,6 @@
 import { 
   createRootNode,
-  createVariationNode,
-  findNodeById,
   addVariation,
-  deleteVariation,
   renameVariation,
   promoteToMainLine,
   getPathToNode,

--- a/src/utils/shogi/validators/basic.ts
+++ b/src/utils/shogi/validators/basic.ts
@@ -228,3 +228,17 @@ export function isUchifuzumeSync(
   
   return true; // 逃げ道がないので打ち歩詰め
 }
+
+// 簡易版：駒打ちが合法かチェックしてエラーメッセージを表示
+export function validateDropWithAlert(
+  board: Board,
+  position: Position,
+  pieceType: PieceType,
+  player: Player
+): boolean {
+  const result = canDropPieceAtWithError(board, position, pieceType, player);
+  if (!result.valid && result.error) {
+    alert(result.error);
+  }
+  return result.valid;
+}


### PR DESCRIPTION
## 概要
将棋の特殊ルール違反を正確に検出し、適切なエラーメッセージを表示する機能を実装しました。

## 変更内容
- エラーメッセージ付きバリデーション関数の追加
- 王手放置のテストケース追加
- 通知コンポーネントの作成
- ゲームボードへのエラー表示統合

Closes #97

Generated with [Claude Code](https://claude.ai/code)